### PR TITLE
modifications to get the mdtc model torch-scriptable

### DIFF
--- a/examples/hi_xiaowen/s0/run.sh
+++ b/examples/hi_xiaowen/s0/run.sh
@@ -102,7 +102,8 @@ if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     --test_data data/test/data.list \
     --batch_size 256 \
     --checkpoint $score_checkpoint \
-    --score_file $result_dir/score.txt
+    --score_file $result_dir/score.txt \
+    --num_workers 8
 fi
 
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then

--- a/kws/model/kws_model.py
+++ b/kws/model/kws_model.py
@@ -18,7 +18,7 @@ from typing import Optional
 import torch
 
 from kws.model.cmvn import GlobalCMVN
-from kws.model.subsampling import LinearSubsampling1, Conv1dSubsampling1
+from kws.model.subsampling import LinearSubsampling1, Conv1dSubsampling1, NoSubsampling
 from kws.model.tcn import TCN, CnnBlock, DsCnnBlock
 from kws.model.mdtc import MDTC
 from kws.utils.cmvn import load_cmvn
@@ -52,8 +52,7 @@ class KWSModel(torch.nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self.global_cmvn is not None:
             x = self.global_cmvn(x)
-        if self.preprocessing:
-            x = self.preprocessing(x)
+        x = self.preprocessing(x)
         x, _ = self.backbone(x)
         x = self.classifier(x)
         x = torch.sigmoid(x)
@@ -82,7 +81,7 @@ def init_model(configs):
     elif prep_type == 'cnn1d_s1':
         preprocessing = Conv1dSubsampling1(input_dim, hidden_dim)
     elif prep_type == 'none':
-        preprocessing = None
+        preprocessing = NoSubsampling()
     else:
         print('Unknown preprocessing type {}'.format(prep_type))
         sys.exit(1)

--- a/kws/model/subsampling.py
+++ b/kws/model/subsampling.py
@@ -23,6 +23,14 @@ class SubsamplingBase(torch.nn.Module):
         super().__init__()
         self.subsampling_rate = 1
 
+class NoSubsampling(SubsamplingBase):
+    """No subsampling in accordance to the 'none' preprocessing
+    """
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
 
 class LinearSubsampling1(SubsamplingBase):
     """Linear transform the input without subsampling


### PR DESCRIPTION
Solved some runtime errors that fail torch-scripting the mdtc model:
1, [kws_model.py, subsampling.py] adding a dummy NoSubsampling preprocessing class since torch script requires a consistent type of a variable in all branches of a control flow
2, [mdtc.py], a ModuleList can only be indexed using int literal, used an iterator workaround instead;
        lists are not a valid function parameter in scripting, implemented causal/non-causal normalization directly without funcs;
        sum is not a supported op and has been rewritten;                  
