### PR TITLE
[kws] fix weight_decay key error

### DIFF
--- a/kws/bin/train.py
+++ b/kws/bin/train.py
@@ -197,7 +197,7 @@ def main():
 
     optimizer = optim.Adam(model.parameters(),
                            lr=configs['optim_conf']['lr'],
-                           weight_decay=configs['optim_conf']['weight_decay'])
+                           weight_decay=configs['optim_conf'].get('weight_decay', 0))
     scheduler = optim.lr_scheduler.ReduceLROnPlateau(
         optimizer,
         mode='min',


### PR DESCRIPTION
Fix weight_decay key error for tcn/ds_tcn/gru models. The default value is 0.0.
``` python
torch.optim.Adam(params, lr=0.001, betas=(0.9, 0.999), eps=1e-08, weight_decay=0, amsgrad=False)
``` 

Now it works.

![image](https://user-images.githubusercontent.com/6036624/144701410-bbe7d74b-6136-43fe-90cb-ba8ff741dd1d.png)
