### PR TITLE
[fix bug] add sigmoid() in score.py

### DIFF
--- a/kws/bin/score.py
+++ b/kws/bin/score.py
@@ -102,7 +102,7 @@ def main():
             feats = feats.to(device)
             lengths = lengths.to(device)
             mask = padding_mask(lengths).unsqueeze(2)
-            logits = model(feats)
+            logits = torch.sigmoid(model(feats))
             logits = logits.masked_fill(mask, 0.0)
             max_logits, _ = logits.max(dim=1)
             max_logits = max_logits.cpu()


### PR DESCRIPTION
The sigmoid() in kws/model/kws_model.py:KWSModel() was moved into kws/model/loss.py:max_pooling_loss()
To compute the posterior score correctly, the sigmoid() should also be added to kws/bin/score.py:main()