### PR TITLE
fix export in export_onnx

### DIFF
--- a/examples/hi_xiaowen/s0/run.sh
+++ b/examples/hi_xiaowen/s0/run.sh
@@ -156,6 +156,6 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
     --jit_model $dir/$jit_model
   python kws/bin/export_onnx.py \
     --config $dir/config.yaml \
-    --jit_model $dir/$jit_model  \
+    --checkpoint $score_checkpoint \
     --onnx_model $dir/$onnx_model
 fi


### PR DESCRIPTION
## What was happening
The following error occurred when exporting a model by export_onnx.py.
`"RuntimeError: Unsupported: ONNX export of Slice with dynamic inputs. DynamicSlice is a deprecated experimental op. Please use statically allocated variables or export to a higher opset version.".`

## What was done
- set opset_version as an argument to export.
- models are now read from checkpoints.
  - the following error occurred when only opset_version was specified.
  - `RuntimeError: Exporting the operator append to ONNX opset version 10 is not supported. Support for this operator was added in version 11, try exporting with this version.`