### PR TITLE
[fix bug] add optimizer.zero_grad() in  kws/utils/executor.py (#72)

### DIFF
--- a/kws/utils/executor.py
+++ b/kws/utils/executor.py
@@ -50,6 +50,7 @@ class Executor:
             grad_norm = clip_grad_norm_(model.parameters(), clip)
             if torch.isfinite(grad_norm):
                 optimizer.step()
+            optimizer.zero_grad()
             if batch_idx % log_interval == 0:
                 logging.debug(
                     'TRAIN Batch {}/{} loss {:.8f} acc {:.8f}'.format(

--- a/kws/utils/executor.py
+++ b/kws/utils/executor.py
@@ -46,11 +46,11 @@ class Executor:
             logits = model(feats)
             loss_type = args.get('criterion', 'max_pooling')
             loss, acc = criterion(loss_type, logits, target, feats_lengths)
+            optimizer.zero_grad()
             loss.backward()
             grad_norm = clip_grad_norm_(model.parameters(), clip)
             if torch.isfinite(grad_norm):
                 optimizer.step()
-            optimizer.zero_grad()
             if batch_idx % log_interval == 0:
                 logging.debug(
                     'TRAIN Batch {}/{} loss {:.8f} acc {:.8f}'.format(


### PR DESCRIPTION
I noticed that in the training stage, when optimizer.step() is called, optimizer.zero_grad() is not called, so I submit this commit to fix this bug.