### PR TITLE
fixed the parameter transfer problem for criterion

### DIFF
--- a/kws/utils/executor.py
+++ b/kws/utils/executor.py
@@ -45,7 +45,7 @@ class Executor:
                 continue
             logits = model(feats)
             loss_type = args.get('criterion', 'max_pooling')
-            loss, acc = criterion(loss_type, logits, target, feats_lengths, 
+            loss, acc = criterion(loss_type, logits, target, feats_lengths,
                                   min_duration)
             optimizer.zero_grad()
             loss.backward()


### PR DESCRIPTION
In wekws/kws/utils/executor.py, line 48:
loss, acc = criterion(loss_type, logits, target, feats_lengths)
change to:
loss, acc = criterion(loss_type, logits, target, feats_lengths, min_duration)