### PR TITLE
Convert target to torch.int64 for cross_entropy

### DIFF
--- a/wekws/model/loss.py
+++ b/wekws/model/loss.py
@@ -169,7 +169,7 @@ def cross_entropy(logits: torch.Tensor, target: torch.Tensor):
         (float): loss of current batch
         (float): accuracy of current batch
     """
-    loss = F.cross_entropy(logits, target)
+    loss = F.cross_entropy(logits, target.type(torch.int64))
     acc = acc_frame(logits, target)
     return loss, acc
 


### PR DESCRIPTION
On my machine the original code threw an error 
RuntimeError: "nll_loss_forward_reduce_cuda_kernel_2d_index" not implemented for 'Int'

I followed https://github.com/wenet-e2e/wekws#installation to setup the environment so I'm curious if this error has ever occured to other people.