### PR TITLE
[ctc]fix false rejection result from long time silence.

### DIFF
--- a/wekws/bin/stream_kws_ctc.py
+++ b/wekws/bin/stream_kws_ctc.py
@@ -485,7 +485,7 @@ class KeyWordSpotter(torch.nn.Module):
         # For streaming kws, the cur_hyps should be reset if the time of
         # a possible keyword last over the max_frames value you set.
         # see this issue:https://github.com/duj12/kws_demo/issues/2
-        if len(self.cur_hyps[0][0]) > 0:
+        if len(self.cur_hyps) > 0 and len(self.cur_hyps[0][0]) > 0:
             keyword_may_start = int(self.cur_hyps[0][1][2][0]['frame'])
             if (self.total_frames - keyword_may_start) > self.max_frames:
                 self.reset()

--- a/wekws/bin/stream_kws_ctc.py
+++ b/wekws/bin/stream_kws_ctc.py
@@ -481,6 +481,15 @@ class KeyWordSpotter(torch.nn.Module):
 
         # update frame offset
         self.total_frames += len(probs) * self.downsampling
+
+        # For streaming kws, the cur_hyps should be reset if the time of
+        # a possible keyword last over the max_frames value you set.
+        # see this issue:https://github.com/duj12/kws_demo/issues/2
+        if len(self.cur_hyps[0][0]) > 0:
+            keyword_may_start = int(self.cur_hyps[0][1][2][0]['frame'])
+            if (self.total_frames - keyword_may_start) > self.max_frames:
+                self.reset()
+
         return self.result
 
     def reset(self):


### PR DESCRIPTION
In the long time online kws case, the CTC kws will cache some results of keyword. If they were not reset properly, it will cause false rejection. You can see this issue https://github.com/duj12/kws_demo/issues/2. This PR is to fix this issue.

